### PR TITLE
Fix model.py predict function

### DIFF
--- a/tn4ml/models/model.py
+++ b/tn4ml/models/model.py
@@ -164,6 +164,8 @@ class Model(qtn.TensorNetwork):
 
             if not return_tn:
                 output = output^all
+                output = output.squeeze()
+                return output.data
 
         if return_tn:
             return output


### PR DESCRIPTION
In order to run the code for the MNIST Classification demos it is necessary to change the following lines in `tn4ml/models/model.py`:

`166            output = output.squeeze()`       
`167            return output.data`