### PR TITLE
Replace `np.Inf` with `np.inf` and format code

### DIFF
--- a/tn4ml/util.py
+++ b/tn4ml/util.py
@@ -18,8 +18,8 @@ def return_digits(array):
 def normalize(v, p=2, atol=1e-9):
     """
     Normalize a vector based on its p-norm, with a check to avoid division by a very small norm.
-    
-    Parameters 
+
+    Parameters
     ----------
     v : jax.numpy.ndarray
         The vector to be normalized.
@@ -27,7 +27,7 @@ def normalize(v, p=2, atol=1e-9):
         The norm type (default is 2).
     atol : Real, optional
         The tolerance level for considering the norm as zero (default is 1e-9).
-    
+
     Returns
     -------
     The normalized vector, or the original vector if its norm is below the tolerance.
@@ -52,7 +52,7 @@ def gramschmidt_row(A, atol=1e-10):
         The norm type (default is 2).
     atol : Real, optional
         The tolerance level for considering vectors as zero (default is 1e-9).
-    
+
     Returns
     -------
     Orthonormal matrix A.
@@ -87,7 +87,7 @@ def gramschmidt_col(A, atol=1e-10):
         The norm type (default is 2).
     atol : Real, optional
         The tolerance level for considering vectors as zero (default is 1e-9).
-    
+
     Returns
     -------
     Orthonormal matrix A.
@@ -109,8 +109,8 @@ def gramschmidt_col(A, atol=1e-10):
     return Q
 
 def gradient_clip(grads, threshold=1.0):
-    """ Clip gradients to a maximum threshold value. 
-    
+    """ Clip gradients to a maximum threshold value.
+
     Parameters
     ----------
     grads : list
@@ -125,7 +125,7 @@ def gradient_clip(grads, threshold=1.0):
     assert threshold > 0, "Threshold must be positive."
     assert len(grads) > 0, "No gradients to clip."
     assert all([len(g) > 0 for g in grads]), "No gradients to clip."
-    
+
     new_grads = []
     for gradients in grads:
         grad_norm = jnp.linalg.norm(gradients)
@@ -136,12 +136,12 @@ def gradient_clip(grads, threshold=1.0):
 
 def zigzag_order(data):
     """ Rearrange pixels in zig-zag order (from https://arxiv.org/pdf/1605.05775.pdf).
-    
+
     Parameters
     ----------
     images : list
         List of images to be rearranged.
-    
+
     Returns
     -------
     List of images with pixels in zig-zag order.
@@ -153,14 +153,14 @@ def zigzag_order(data):
 
 def integer_to_one_hot(labels, num_classes=None):
     """ Convert integer labels to one-hot encoded labels.
-    
+
     Parameters
     ----------
     labels : list
         List of integer labels.
     num_classes : int, optional
         Number of classes (default is None).
-    
+
     Returns
     -------
     One-hot encoded labels.
@@ -197,19 +197,19 @@ def pad_image_alternately(image: np.ndarray, k: int) -> np.ndarray:
 
     # Determine padding required
     pad = (k - H % k) % k
-    
+
     # Alternate padding by adding to left or right as necessary
     top_pad, bottom_pad = (pad//2, pad//2) if pad % 2 == 0 else (pad//2 + 1, pad//2)
     left_pad, right_pad = (pad//2, pad//2) if pad % 2 == 0 else (pad//2 + 1, pad//2)
-    
+
     # Apply padding in a single operation
     padded_image = jnp.pad(
-        image, 
-        ((top_pad, bottom_pad), (left_pad, right_pad)), 
-        mode='constant', 
+        image,
+        ((top_pad, bottom_pad), (left_pad, right_pad)),
+        mode='constant',
         constant_values=0
     )
-    
+
     return padded_image
 
 def divide_into_patches(image: np.ndarray, k: int) -> np.ndarray:
@@ -230,18 +230,18 @@ def divide_into_patches(image: np.ndarray, k: int) -> np.ndarray:
     """
     # Pad the image to ensure it's divisible by k
     padded_image = pad_image_alternately(image, k) if image.shape[0] % k != 0 else image
-    
+
     H, W = padded_image.shape
 
     # Reshape and move axes to create kxk patches
     patches = padded_image.reshape(H // k, k, W // k, k).swapaxes(1, 2).reshape(-1, k, k)
-    
+
     return jnp.array(patches)
 
 def from_dense_to_mps(statevector: jnp.ndarray, n_qubits: int, max_bond: int = None) -> List[jnp.ndarray]:
     """
     Convert a dense statevector to a Matrix Product State (MPS) representation in JAX.
-    
+
     Parameters
     ----------
     statevector: jnp.ndarray
@@ -250,7 +250,7 @@ def from_dense_to_mps(statevector: jnp.ndarray, n_qubits: int, max_bond: int = N
         The number of qubits (log2 of the statevector length).
     max_bond: int, optional
         The maximum bond dimension for truncating the MPS tensors.
-        
+
     Returns
     -------
     list[:class:`jax.numpy.ndarray`]
@@ -258,7 +258,7 @@ def from_dense_to_mps(statevector: jnp.ndarray, n_qubits: int, max_bond: int = N
     """
     # Step 1: Reshape the statevector to a tensor of shape (2, 2, ..., 2)
     psi = statevector.reshape((2,) * n_qubits)
-    
+
     # Initialize a list to store MPS tensors
     mps = []
     current_tensor = psi
@@ -272,18 +272,18 @@ def from_dense_to_mps(statevector: jnp.ndarray, n_qubits: int, max_bond: int = N
 
         # Step 2: Perform SVD
         u, s, vh = jnp.linalg.svd(current_tensor, full_matrices=False)
-        
+
         # Truncate based on max bond dimension
         bond_dim = s.shape[0] if max_bond is None else min(s.shape[0], max_bond)
         u = u[:, :bond_dim]
         s = s[:bond_dim]
         vh = vh[:bond_dim, :]
-        
+
         # Reshape `u` to the `LRP` format
         right_bond = bond_dim
         mps_tensor = u.reshape(left_bond, physical_dim, right_bond).transpose([0, 2, 1]) # (l, p, r) -> (l, r, p)
         mps.append(mps_tensor)
-        
+
         # Move the singular values into the next tensor
         current_tensor = jnp.diag(s) @ vh
         left_bond = right_bond  # Update left_bond for the next tensor
@@ -297,26 +297,26 @@ def from_dense_to_mps(statevector: jnp.ndarray, n_qubits: int, max_bond: int = N
 
     # Final tensor for the last site with shape (left_bond, 1, physical_dim=2)
     mps.append(current_tensor.reshape(left_bond, physical_dim, 1).transpose([0, 2, 1]))
-    
+
     return mps
 
 
 def from_mps_to_dense(mps: List[jnp.ndarray], n_qubits: int) -> jnp.ndarray:
     """
     Convert a Matrix Product State (MPS) representation back to a dense statevector.
-    
+
     Parameters
     ----------
     mps: List[jnp.ndarray]
         A list of MPS tensors where each tensor has the shape "lrp".
     n_qubits: int
         The number of qubits.
-    
+
     Returns
     -------
     :class:`jax.numpy.ndarray`
         The dense statevector as a 1D array of length 2^n_qubits.
-    
+
     """
     # Start with the first MPS tensor.
     statevector = mps[0].transpose([0, 2, 1])  # (l, r, p) -> (l, p, r)
@@ -350,7 +350,7 @@ class EarlyStopping:
         self.min_delta = min_delta
         self.patience = patience
         self.mode = mode
-    
+
     def on_begin_train(self, history):
         """
         Set up the memory for the early stopping algorithm.
@@ -359,7 +359,7 @@ class EarlyStopping:
         ----------
         history : dict
             The dictionary containing the training history.
-        
+
         Raises
         ------
         ValueError
@@ -373,7 +373,7 @@ class EarlyStopping:
             raise ValueError(f'EarlyStopping mode can be either "min" or "max".')
 
         self.memory = dict()
-        self.memory['best'] = np.Inf if self.mode == 'min' else -np.Inf
+        self.memory['best'] = np.inf if self.mode == 'min' else -np.inf
         self.memory['best_epoch'] = 0 # track on each epoch
         if self.mode == 'min':
             self.min_delta = self.min_delta*(-1)
@@ -382,7 +382,7 @@ class EarlyStopping:
             self.min_delta = self.min_delta*1
             self.operator = np.greater
         self.memory['wait'] = 0
-    
+
     def on_end_epoch(self, loss_current, epoch):
         """
         Check if the training should be stopped based on the monitored metric.
@@ -393,7 +393,7 @@ class EarlyStopping:
             The value of the monitored metric.
         epoch : int
             The current epoch number.
-        
+
         Returns
         -------
         int
@@ -416,7 +416,7 @@ class EarlyStopping:
             print(f'Training stopped by EarlyStopping on epoch: {best_epoch}', flush=True)
             self = self.memory['best_model']
             return 1
-        if self.memory['wait'] > 0: 
+        if self.memory['wait'] > 0:
             print('Waiting for ' + str(self.memory['wait']) + ' epochs.', flush=True)
-        
+
         return 0


### PR DESCRIPTION
### Summary
This PR replaces instances of `np.Inf` with `np.inf` for consistency and to align with NumPy's preferred usage. The lowercase version (`np.inf`) is standard and ensures better compatibility with current and future NumPy versions, where the `np.Inf` is not supported anymore. 

Additionally, some code has been formatted where there were unnecessary empty spaces.

#### Changes
- Replaced np.Inf with np.inf
- Applied minor code formatting
