### PR TITLE
Fixing errors due to mismatch in embedding class names

### DIFF
--- a/docs/source/embeddings.rst
+++ b/docs/source/embeddings.rst
@@ -13,20 +13,20 @@ Trigonometric
 
 Fourier
 ^^^^^^^
-.. autoclass:: tn4ml.embeddings.fourier
+.. autoclass:: tn4ml.embeddings.FourierEmbedding
    :members:
    :undoc-members:
    :noindex:
 
 Linear Complement
 ^^^^^^^^^^^^^^^^^^
-.. autoclass:: tn4ml.embeddings.linear_complement_map
+.. autoclass:: tn4ml.embeddings.LinearComplementEmbedding
    :members:
    :undoc-members:
 
 Gaussian RBF
 ^^^^^^^^^^^^
-.. autoclass:: tn4ml.embeddings.gaussian_rbf
+.. autoclass:: tn4ml.embeddings.GaussianRBFEmbedding
    :members:
    :undoc-members:
 
@@ -38,7 +38,13 @@ Polynomial
 
 Jax Arrays
 ^^^^^^^^^^
-.. autoclass:: tn4ml.embeddings.jax_arrays
+.. autoclass:: tn4ml.embeddings.JaxArraysEmbedding
+   :members:
+   :undoc-members:
+
+Patch Amplitude Embedding
+^^^^^^^^^^^^^^^
+.. autoclass:: tn4ml.embeddings.PatchAmplitudeEmbedding
    :members:
    :undoc-members:
 

--- a/docs/source/embeddings.rst
+++ b/docs/source/embeddings.rst
@@ -43,7 +43,7 @@ Jax Arrays
    :undoc-members:
 
 Patch Amplitude Embedding
-^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^
 .. autoclass:: tn4ml.embeddings.PatchAmplitudeEmbedding
    :members:
    :undoc-members:

--- a/tn4ml/__init__.py
+++ b/tn4ml/__init__.py
@@ -10,12 +10,12 @@ from .initializers import (
 )
 from .embeddings import (
     Embedding,
-    trigonometric,
-    fourier,
-    polynomial,
-    linear_complement_map,
-    gaussian_rbf,
-    jax_arrays,
+    TrigonometricEmbedding, 
+    FourierEmbedding, 
+    PolynomialEmbedding, 
+    LinearComplementEmbedding, 
+    GaussianRBFEmbedding, 
+    JaxArraysEmbedding,
     PatchAmplitudeEmbedding,
     PatchEmbedding,
     embed


### PR DESCRIPTION
Hello,

Thanks for sharing your very nice repo with the community! 

Today I tried to run your example notebook and noticed a couple of errors due to a mis-match in the embeddings.py class names.  The impact and fixes for these errors are summarized below.

1) imports -> fixed in tn4ml/__init__.py
2) docs -> fixed in docs/source/embeddings.rst

I look forward to exploring your library further.

Cheers,

Laura