### PR TITLE
Feature#32 - Fix windows install problem, update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ It supports different **embedding** functions, **initialization** techniques, **
 First create a virtualenv using `pyenv` or `conda`. Then install the package and its dependencies.
 <br>
 
-**With** `pip` (tag v1.0.5):
+**With** `pip` (tag v1.1.0):
 ```bash
 pip install tn4ml
 ```

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,39 +1,84 @@
 Tensor Networks for Machine Learning
 ====================================
 
+**tn4ml** is a Python library for using Tensor Networks in Machine Learning
+applications.
+
+It is built on top of `Quimb <https://quimb.readthedocs.io>`_ for
+the tensor network objects and `JAX <https://docs.jax.dev>`_ for the optimization
+pipeline.
+
+The library currently supports 1D tensor network structures:
+
+- **Matrix Product State** (MPS)
+- **Matrix Product Operator** (MPO)
+- **Spaced Matrix Product Operator** (SMPO)
+
+together with a range of **embedding** functions, **initialization** techniques,
+**objective functions**, and **optimization strategies** that can be mixed and
+matched to build and train your own models.
+
+Quickstart
+----------
+
+Install from PyPI:
+
+.. code-block:: bash
+
+   pip install tn4ml
+
+Then train a model in a few lines:
+
+.. code-block:: python
+
+   from tn4ml.models import MPS_initialize
+
+   # 1. Initialize a tensor network model (e.g. a Matrix Product State)
+   model = MPS_initialize(L=n_features, ...)
+
+   # 2. Configure the optimization pipeline (optimizer, loss, strategy, device)
+   model.configure(...)
+
+   # 3. Train on your embedded data
+   history = model.train(data)
+
+See :doc:`source/install` for GPU setup and development installs, and
+:doc:`source/examples` for end-to-end notebooks.
+
+Where to go next
+----------------
+
+- :doc:`source/install` — installation, accelerated runtime, and GPU support.
+- :doc:`source/api` — full API reference for models, embeddings, initializers,
+  metrics, strategies, and evaluation.
+- :doc:`source/examples` — worked examples for classification, anomaly
+  detection, and the experiments from our paper.
+- :doc:`source/changelog` — release notes and version history.
+
+Citation
+--------
+
+If you use **tn4ml** in your work, please cite
+`arXiv:2502.13090 <https://arxiv.org/abs/2502.13090>`_:
+
+.. code-block:: bibtex
+
+   @article{puljak2025tn4mltensornetworktraining,
+         title={tn4ml: Tensor Network Training and Customization for Machine Learning},
+         author={Ema Puljak and Sergio Sanchez-Ramirez and Sergi Masot-Llima and Jofre Vallès-Muns and Artur Garcia-Saez and Maurizio Pierini},
+         year={2025},
+         eprint={2502.13090},
+         archivePrefix={arXiv},
+         primaryClass={cs.LG},
+         url={https://arxiv.org/abs/2502.13090},
+   }
+
 .. toctree::
    :maxdepth: 2
    :titlesonly:
-   :caption: Getting started
+   :hidden:
 
    source/install
-
-.. toctree::
-   :maxdepth: 1
-   :titlesonly:
-   :caption: Modules
-
-   source/tn4ml.models
-   source/initializers
-   source/embeddings
-   source/metrics
-   source/strategy
-   source/eval
-
-.. toctree::
-   :maxdepth: 1
-   :titlesonly:
-   :caption: Examples
-
-   source/examples/tn_tutorial
-   source/examples/mnist_classification
-   source/examples/mnist_ad
-   source/examples/mnist_ad_sweeps
-   source/examples/tnad_latent/index.rst
-
-.. toctree::
-   :maxdepth: 1
-   :titlesonly:
-   :caption: Changelog
-
+   source/api
+   source/examples
    source/changelog

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -30,3 +30,10 @@ Tensor Networks for Machine Learning
    source/examples/mnist_ad
    source/examples/mnist_ad_sweeps
    source/examples/tnad_latent/index.rst
+
+.. toctree::
+   :maxdepth: 1
+   :titlesonly:
+   :caption: Changelog
+
+   source/changelog

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -1,0 +1,12 @@
+API reference
+*************
+
+.. toctree::
+   :maxdepth: 1
+
+   tn4ml.models
+   initializers
+   embeddings
+   metrics
+   strategy
+   eval

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,0 +1,102 @@
+Changelog
+*********
+
+All notable changes to **tn4ml** are documented here.
+
+v1.1.0
+======
+
+**Fixed**
+
+- **Windows installation.** Pinned ``orbax-checkpoint>=0.11.34`` so the transitive
+  ``uvloop`` dependency (which has no Windows wheels) is correctly skipped on
+  Windows. ``orbax-checkpoint==0.11.33`` declared ``uvloop`` unconditionally, which
+  broke ``pip install tn4ml`` on Windows; ``0.11.34+`` guards it with
+  ``platform_system != "Windows"``. The previous ``pip install --no-deps tn4ml``
+  workaround is no longer needed.
+- Fixed ``mypy`` errors across the codebase (#39).
+
+**Changed**
+
+- **Removed the hardcoded** ``softmax`` from the model — this affects model output
+  and evaluation (#40).
+- Updated the batching function in ``model.py`` (#37).
+- Dropped support for Python < 3.10.
+- Renamed the ``test/`` directory to ``tests/``.
+- Updated example notebooks and refined extra dependencies.
+
+**Added**
+
+- Developer tooling: pre-commit hooks and CI pre-merge checks (``ruff``, ``mypy``,
+  ``bandit``), plus automatic version inheritance in the CI/CD pipeline (#37).
+
+v1.0.5
+======
+
+**Changed**
+
+- Refined ``extras_require`` in ``setup.py`` to ensure correct installation of the
+  example dependencies. Install them with ``pip install "tn4ml[examples]"``.
+
+**Added**
+
+- New example scripts from the paper
+  *"tn4ml: Tensor Network Training and Customization for Machine Learning"*.
+- Updated documentation.
+
+v1.0.4
+======
+
+**Fixed**
+
+- Normalization issue for large systems (#28).
+- Corrected canonization in ``Strategy.Sweeps``.
+
+**Added**
+
+- ``device`` option in ``Model.configure()`` (#26).
+- Updated example notebooks.
+
+v1.0.3
+======
+
+**Fixed**
+
+- Model training and evaluation (#19).
+- Validation and model saving issues (#17).
+- ``metrics.CombinedLoss()``.
+
+**Added**
+
+- New ``PatchAmplitudeEmbedding`` embedding (#20, thanks @gabrieledangeli).
+- ``model.forward()`` function.
+
+v1.0.2
+======
+
+**Fixed**
+
+- Fix in ``initializers.py``.
+- Fix in ``model.py`` — affects model evaluation.
+
+v1.0.1
+======
+
+**Added**
+
+- A few new features for embeddings.
+
+**Fixed**
+
+- Bug fixes and performance improvements.
+- Minor issues found in version 1.0.0.
+
+v1.0.0
+======
+
+**Added**
+
+- Initial release of **tn4ml**: tensor networks for machine learning built on top
+  of Quimb and JAX, with support for 1D tensor network structures (Matrix Product
+  State, Matrix Product Operator, Spaced Matrix Product Operator), embeddings,
+  initializers, objective functions, and optimization strategies.

--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -1,0 +1,11 @@
+Examples
+********
+
+.. toctree::
+   :maxdepth: 1
+
+   examples/tn_tutorial
+   examples/mnist_classification
+   examples/mnist_ad
+   examples/mnist_ad_sweeps
+   examples/tnad_latent/index

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", encoding="utf-8") as fh:  # noqa: PTH123
 
 setup(
     name="tn4ml",
-    version="1.0.5",
+    version="1.1.0",
     author="Ema Puljak, Sergio Sanchez Ramirez, Sergi Masot Llima, Jofre Vallès-Muns",
     description="Tensor Networks for Machine Learning",
     long_description=long_description,
@@ -35,6 +35,7 @@ setup(
         "jax",
         "optax",
         "flax",
+        "orbax-checkpoint>=0.11.34",
         "pandas",
         "nevergrad",
         "optuna",


### PR DESCRIPTION
## Fix Windows installation & overhaul docs

### Summary

Fixes the Windows installation failure caused by the transitive `uvloop` dependency, bumps the release to **v1.1.0**, and reworks the documentation (changelog, navbar structure, and landing page). Closes #32.

### Why

On Windows, `pip install tn4ml` failed because `orbax-checkpoint==0.11.33` (pulled in via `flax`) declared `uvloop` as an **unconditional** dependency, and `uvloop` ships no Windows wheels. The only workaround was `pip install --no-deps tn4ml` followed by manual dependency installation.

`orbax-checkpoint==0.11.34` fixed this upstream by guarding the dependency with `platform_system != "Windows"`.

### Changes

**Windows install fix**
- Pin `orbax-checkpoint>=0.11.34` in `setup.py` so the resolver never selects the broken `0.11.33`, and `uvloop` is correctly skipped on Windows. The `--no-deps` workaround is no longer needed.
- Bump version `1.0.5` → `1.1.0`.

**Docs**
- Add `docs/source/changelog.rst` documenting all releases (v1.0.0 → v1.1.0), wired into the docs.
- Restructure the navbar to four top-level items — **Installation · API reference · Examples · Changelog** — by grouping the modules under a new `api.rst` and the notebooks under a new `examples.rst` landing page.
- Replace the empty docs home page with a meaningful landing page: intro, quickstart snippet, cross-links, and citation.
- Update the install tag reference in `README.md` to `v1.1.0`.

### Versioning note

Released as **1.1.0** (minor, not a patch): this line also removed the hardcoded `softmax` (changes model output/evaluation) and dropped Python < 3.10 support — both beyond a bug fix.

### Testing

- [x] `pip install .` succeeds on Windows without `--no-deps`
- [x] `sphinx-build -b html docs docs/build/html` builds cleanly and the navbar shows the four expected items
